### PR TITLE
Add arm to platforms

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -7,6 +7,7 @@ description: |
 
 platforms:
   amd64:
+  arm64:
 
 services:
   go:


### PR DESCRIPTION
I'm on mac with ARM chip and needed to add arm64 to the platforms to resolve this error on mulipass
```
ubuntu@min-multipass:~/charmed-nodejs-boilerplate$ rockcraft pack
No build matches the current execution environment.
Recommended resolution: Check the project's 'platforms' declaration, and the '--platform' and '--build-for' parameters.
Full execution log: '/home/ubuntu/.local/state/rockcraft/log/rockcraft-20250710-123807.655836.log'
```
