### PR TITLE
 Restore workload version on start

### DIFF
--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -25,6 +25,11 @@ class CharmedNodejsBoilerplateCharm(paas_charm.expressjs.Charm):
         """
         super().__init__(*args)
 
+        self.framework.observe(self.on.start, self._on_start)
+
+    def _on_start(self, event: ops.StartEvent):
+        # The workload exposes the version via HTTP at /version
+        self.unit.set_workload_version("0.0.3")
 
 if __name__ == "__main__":
     ops.main(CharmedNodejsBoilerplateCharm)

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -3,7 +3,7 @@ name: charmed-nodejs-boilerplate
 # for more information about bases and using 'bare' bases for chiselled rocks
 base: bare # as an alternative, a ubuntu base can be used
 build-base: ubuntu@24.04 # build-base is required when the base is bare
-version: '0.0.3' # just for humans. Semantic versioning is recommended
+version: "0.0.3" # just for humans. Semantic versioning is recommended
 summary: A summary of your ExpresssJS application # 79 char long summary
 description: |
     This is charmed-nodejs-boilerplate's description. You have a paragraph or two to tell the


### PR DESCRIPTION
## Done

- Some of the code [here](https://github.com/canonical/charmed-nodejs-boilerplate/commit/63f795ebdbdfb56f42d7c33cdc39a21fe8cc1b98) was missing from the previous PR. 
- Restored workload version setting in `charm.py`

## QA

- Run `/scripts/packanddeploy.sh`
- Check the correct version is set
